### PR TITLE
Run standalone tests on GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: rhizo
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache venv contents
+      id: cache-venv
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+
+    - name: Install dependencies into venv
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        if [ "${{ matrix.python-version }}" = "2.7" ]; then
+          pip install virtualenv
+          virtualenv .venv
+        else
+          python -m venv .venv
+        fi
+        source .venv/bin/activate
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r rhizo/extensions/requirements.txt
+        pip install -r tests/requirements.txt
+
+    - name: Prep config
+      run: |
+        cp sample_config.hjson config.hjson
+
+    - name: Test with pytest
+      run: |
+        .venv/bin/pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.py[cod]
 config.hjson
 local.hjson
+logs
+.venv

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ rhizo
 
 Install dependencies:
 
-    pip install gevent
-    pip install ws4py
-    pip install hjson
+    pip install -r requirements.txt
 
-Note: some extensions may have additional dependencies (e.g., pyserial, pillow).
+Note: some extensions may have additional dependencies (e.g., pyserial, pillow). To install the dependencies for the built-in extensions, run
+
+    pip install -r rhizo/extensions/requirements.txt
 
 Add the `rhizo` folder to your `PYTHONPATH`.
 
@@ -28,3 +28,15 @@ The rhizo controller reads a `config.hjson` file and optionally `local.hjson` fi
 Typically the `config.hjson` file can be stored in version control while `local.hjson` contains system-specific
 settings and items such as secret keys that should not be in version control. Entries in the `local.hjson` file
 override settings in `config.hjson`.
+
+## Tests
+
+There are two test directories. `tests` contains standalone tests and `tests_with_server` has tests that require a running rhizo-server instance.
+
+To run the standalone tests, first install the test dependencies (you only need to do this once):
+
+    pip install -r tests/requirements.txt
+
+Then run `pytest tests`.
+
+To run the server-based tests, create `tests_with_server/local.hjson` with your server settings and execute the test files directly (that is, don't run them under pytest). Make sure your `PYTHONPATH` is set correctly to find the library!

--- a/rhizo/controller.py
+++ b/rhizo/controller.py
@@ -33,7 +33,7 @@ class Controller(object):
     # ======== initialization ========
 
     # prepare internal data
-    def __init__(self):
+    def __init__(self, configuration=None):
 
         # initialize member variables
         self.config = None  # publicly accessible
@@ -56,11 +56,15 @@ class Controller(object):
         parser.add_option('-v', '--verbose', dest='verbose', action='store_true', default=False)
         (options, args) = parser.parse_args()
 
-        # load config file
-        self._config_relative_file_name = options.config_file_name
-        self.load_config()
-        if not self.config:
-            sys.exit(1)
+        if configuration:
+            self.config = config.Config(configuration)
+            self._config_relative_file_name = '(passed by caller)'
+        else:
+            # load config file
+            self._config_relative_file_name = options.config_file_name
+            self.load_config()
+            if not self.config:
+                sys.exit(1)
 
         # initialize other controller attributes
         if self.config.get('enable_keyboard_monitor', False):

--- a/rhizo/extensions/requirements.txt
+++ b/rhizo/extensions/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+pyserial

--- a/rhizo/extensions/serial_.py
+++ b/rhizo/extensions/serial_.py
@@ -4,7 +4,6 @@ import collections
 import gevent
 import serial as pyserial
 from rhizo import util
-from device import Device
 
 
 # The Port object manages a connection a single serial port.
@@ -87,7 +86,7 @@ class Serial(object):
         # temp handle device without port
         if not device.port_name():
             if self._ports:
-                device._port_name = self._ports.keys()[0]
+                device._port_name = list(self._ports.keys())[0]
             else:
                 device._port_name = 'sim'
         if (device.port_name(), device.device_id()) in self._devices:
@@ -123,7 +122,7 @@ class Serial(object):
             for port in self._ports:
                 self._ports[port].write_command(message)
         if self._ports:
-            port_name = self._ports.keys()[0]  # note: only works with single serial port
+            port_name = list(self._ports.keys())[0]  # note: only works with single serial port
         else:
             port_name = 'sim'
         device_key = (port_name, device_id)

--- a/sample_config.hjson
+++ b/sample_config.hjson
@@ -1,1 +1,1 @@
-server_name example.com
+server_name: example.com

--- a/test_provisioning/.gitignore
+++ b/test_provisioning/.gitignore
@@ -1,4 +1,0 @@
-local.hjson
-logs
-.cache
-__pycache__

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,5 @@
+local.hjson
+logs
 .cache
 __pycache__
 .pytest_cache

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pathlib # Needed for Python 2
+pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
-import py.test
+from pathlib import Path
+
 from rhizo.config import load_config
 
 
@@ -9,28 +10,30 @@ def check_config(config):
     assert round(config.sub_config.c - 3.14, 4) == 0
 
 
+def _load_test_config(filename):
+    """Load a config file from the test_data subdirectory."""
+    path = Path(__file__).parent / 'test_data' / filename
+    return load_config(str(path))
+
+
 def test_text_config():
-    config = load_config('test_data/sample_config.txt')
+    config = _load_test_config('sample_config.txt')
     check_config(config)
 
 
 def test_json_config():
-    config = load_config('test_data/sample_config.json')
+    config = _load_test_config('sample_config.json')
     check_config(config)
 
 
 def test_hjson_config():
-    config = load_config('test_data/sample_config.hjson')
+    config = _load_test_config('sample_config.hjson')
     check_config(config)
 
 
 def test_config_update():
-    config = load_config('test_data/sample_config.hjson')
-    config.update(load_config('test_data/update.hjson'))
+    config = _load_test_config('sample_config.hjson')
+    config.update(_load_test_config('update.hjson'))
     assert config.output_path == '/foo/test'
     assert config.sub_config.a == 'test'
     assert config.sub_config.b == 3
-
-
-if __name__ == '__main__':
-    test_test()

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,8 +1,7 @@
-import logging
-from rhizo.main import c
+from rhizo.controller import Controller
 from rhizo.util import crc16_ccitt
-from rhizo.extensions.serial_ import Port
 from rhizo.extensions.device import Device
+from rhizo.extensions.serial_ import Port
 
 
 # a mock serial connection for testing the serial extension
@@ -44,10 +43,10 @@ class MockSerialConnection(object):
 
 
 # basic test of serial using mock serial port
-def test_serial():
-
+def test_serial_polling():
     # open a mock serial port
     mock_conn = MockSerialConnection()
+    c = Controller({'extensions': ['serial'], 'enable_server': False, 'serial': {'polling': True}})
     c.serial._ports['mock'] = Port(mock_conn)
 
     # create a test device
@@ -59,8 +58,3 @@ def test_serial():
     # wait until polled
     while not mock_conn.polled:
         c.sleep(0.1)
-
-
-# if run as a top-level script
-if __name__ == '__main__':
-    test_serial()

--- a/tests_with_serial/.gitignore
+++ b/tests_with_serial/.gitignore
@@ -1,5 +1,0 @@
-local.hjson
-logs
-.cache
-__pycache__
-.pytest_cache


### PR DESCRIPTION
Make the non-server-based tests run under pytest, consolidate them into the
`tests` directory, and add a GitHub Actions configuration to run them on pushes
and PRs.

This required making a couple minor changes to the library code: `Controller` can
now be passed a configuration dict programmatically, and the `serial_` module is
now compatible with Python 3's ordered dict `keys()` method.