### PR TITLE
Obey MQTT TLS configuration for remote hosts

### DIFF
--- a/rhizo/messages.py
+++ b/rhizo/messages.py
@@ -61,7 +61,7 @@ class MessageClient(object):
             self._client.on_disconnect = on_disconnect
             self._client.on_message = on_message
             self._client.username_pw_set('key', self._controller.config.secret_key)
-            if mqtt_tls or (mqtt_host != 'localhost' and mqtt_host != '127.0.0.1'):
+            if mqtt_tls:
                 self._client.tls_set()  # enable SSL
             self._client.connect(mqtt_host, mqtt_port)
             self._client.loop_start()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(str(here / 'README.md')) as f:
 
 setup(
     name='rhizo-client',
-    version='0.1.0',
+    version='0.1.1',
     description='Client for rhizo-server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
When the client is running in a separate Docker container from the MQTT server
in bridge network mode, the server does not have a localhost address even though
it isn't actually remote. Drop the localhost-only restriction and obey the config
option unconditionally.
