### PR TITLE
Support server-generated MQTT credentials, client-side folder name configuration

### DIFF
--- a/rhizo/controller.py
+++ b/rhizo/controller.py
@@ -173,8 +173,11 @@ class Controller(object):
     # get the path of the controller folder on the server
     def path_on_server(self):
         if not self._path_on_server:
-            file_info = self.files.file_info('/self')
-            self._path_on_server = file_info['path']
+            if self.config.get('path_prefix'):
+                self._path_on_server = self.config['path_prefix']
+            else:
+                file_info = self.files.file_info('/self')
+                self._path_on_server = file_info['path']
         return self._path_on_server
 
     # add a custom handler for errors
@@ -312,6 +315,15 @@ class Controller(object):
         # update in-memory config
         self.config.secret_key = secret_key
         self.files._secret_key = secret_key
+
+    def request_mqtt_credentials(self):
+        """Ask the server for credentials that may be presented to the MQTT broker.
+
+        Return a dict with "username" and "password" keys.
+        """
+        response = json.loads(self.files.send_request_to_server('POST', '/api/v1/mqtt/credentials'))
+        logging.debug('Got JWT from server: username %s password %s', response['username'], response['password'])
+        return response
 
 
 # a custom log handler for sending logged messages to server (in a log sequence)

--- a/rhizo/messages.py
+++ b/rhizo/messages.py
@@ -33,6 +33,7 @@ class MessageClient(object):
         # MQTT connection
         if 'mqtt_host' in self._controller.config:
             mqtt_host = self._controller.config.mqtt_host
+            mqtt_request_credentials = self._controller.config.get('mqtt_request_credentials', False)
             mqtt_port = self._controller.config.get('mqtt_port', 443)
             mqtt_tls = self._controller.config.get('mqtt_tls', True)
 
@@ -60,7 +61,12 @@ class MessageClient(object):
             self._client.on_connect = on_connect
             self._client.on_disconnect = on_disconnect
             self._client.on_message = on_message
-            self._client.username_pw_set('key', self._controller.config.secret_key)
+            if mqtt_request_credentials:
+                mqtt_creds = self._controller.request_mqtt_credentials()
+                self._client.username_pw_set(mqtt_creds['username'], mqtt_creds['password'])
+            else:
+                password = self._controller.config.secret_key
+                self._client.username_pw_set('key', password)
             if mqtt_tls:
                 self._client.tls_set()  # enable SSL
             self._client.connect(mqtt_host, mqtt_port)

--- a/rhizo/sample_config.yaml
+++ b/rhizo/sample_config.yaml
@@ -1,1 +1,11 @@
 server_name: example.com
+
+# Set this to true to make the client request MQTT credentials from the server. This can be
+# useful if the MQTT broker is configured to support JWT authentication such that a new token
+# needs to be generated for each session. Default is to authenticate with the secret key.
+#mqtt_request_credentials: false
+
+# Set this to override the path of the resource folder associated with this controller;
+# individual resource paths are prefixed with this folder name. By default, the folder name
+# is queried from the server. The first character should be a forward slash.
+#path_prefix: /x/y/z

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(str(here / 'README.md')) as f:
 
 setup(
     name='rhizo-client',
-    version='0.1.2',
+    version='0.1.3',
     description='Client for rhizo-server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
To support switching over to JWT authentication for Mosquitto, add a config option
that makes the client request its MQTT credentials via an HTTP API endpoint.

To support clients that are associated with organizations but need to report
device data for sites within the organization, allow the resource path prefix to
be set in configuration instead of fetched from the server.

The default behavior remains unchanged.
